### PR TITLE
Fix Three.js deprecation warning by migrating to ES Modules

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 // Modern JavaScript for professional personal website
 document.addEventListener('DOMContentLoaded', function() {
     // Theme management
@@ -664,7 +666,6 @@ function updateMapTheme(theme) {
 
 // ─── Three.js Hero Scene: Scroll-Driven 3D Career Journey ────────────────────
 function initThreeScene() {
-    if (!window.THREE) return;
     const canvas = document.getElementById('three-canvas');
     if (!canvas) return;
 

--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@
     <button class="back-to-top" id="back-to-top" aria-label="Back to top">↑</button>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
-    <script src="client/app.js"></script>
+    <script type="importmap">{"imports": {"three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.min.js"}}</script>
+    <script type="module" src="client/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary                                                                                                                                                                                     
                                                                                                                                                                                                 
  - Replaced the deprecated `build/three.min.js` UMD bundle (removed in r160+) with the ES Module build via `importmap` + `type="module"` script tag, per the official Three.js migration guide  
  - Added `import * as THREE from 'three'` to `app.js` and removed the now-redundant `window.THREE` guard                                                                                        
                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                     
                                                                                                                                                                                                 
  - **`index.html`**: swap `<script src="three.min.js">` → `<script type="importmap">` + `<script type="module" src="client/app.js">`                                                            
  - **`client/app.js`**: add ESM import at top; drop `if (!window.THREE) return` guard                                                                                                           
                                                                                                                                                                                               
  ## Notes                                                                                                                                                                                       
                                                                                                                                                                                                 
  Three.js CDN source updated to `cdn.jsdelivr.net` (faster, more reliable than unpkg for ESM). No functional changes to the 3D scene.    