### PR TITLE
Fix Three.js canvas rendering on top of page content

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -771,7 +771,9 @@ function initThreeScene() {
     // ── Theme-reactive clear color (makes scene visible on light background) ──
     function syncTheme() {
         const light = document.documentElement.getAttribute('data-theme') === 'light';
-        renderer.setClearColor(light ? 0x0d1b3e : 0x000000, light ? 0.22 : 0);
+        // Dark mode: renderer owns the full background color
+        // Light mode: subtle dark tint so glowing particles are visible
+        renderer.setClearColor(light ? 0x0d1b3e : 0x0f172a, light ? 0.22 : 1);
     }
     syncTheme();
     document.querySelector('.theme-toggle')?.addEventListener('click', () =>

--- a/client/static/css/style.css
+++ b/client/static/css/style.css
@@ -72,9 +72,13 @@ html {
     font-size: 16px;
 }
 
+html {
+    background: var(--background-dark); /* fallback before canvas renders */
+}
+
 body {
     font-family: var(--font-family);
-    background: var(--background-dark);
+    background: transparent;
     color: var(--text-primary);
     line-height: 1.6;
     min-height: 100vh;
@@ -256,7 +260,7 @@ body {
     height: 100%;
     display: block;
     pointer-events: none;
-    z-index: 0;
+    z-index: -1;
 }
 
 /* Main content sits above the canvas */


### PR DESCRIPTION
## Problem                                                                                                                                                                                     
                                                                                                                                                                                                 
  The Three.js canvas (`z-index: 0`) was overlapping the header and main content instead of rendering behind them. Using `z-index: 0` on a `position: fixed` element is ambiguous — it competes  
  within the same stacking context as page content.                                                                                                                                              
                                                                                                                                                                                                 
  ## Fix                                                                                                                                                                                         
                                                                                                                                                                                                 
  - **`z-index: -1`** on `#three-canvas` — unambiguously places the canvas below all document content regardless of stacking contexts
  - **`body { background: transparent }`** — prevents the body background from covering the canvas                                                                                               
  - **`html { background: var(--background-dark) }`** — theme-aware fallback color before the canvas initializes (prevents flash of white)                                                     
  - **`renderer.setClearColor(0x0f172a, 1)`** in dark mode — renderer now owns the page background color directly instead of relying on the body  